### PR TITLE
Rename All, None and ST into AllOps, NoOps and STFlag

### DIFF
--- a/state/Backtranslation.STLCToTargetLang.fst
+++ b/state/Backtranslation.STLCToTargetLang.fst
@@ -75,19 +75,19 @@ let mk_targetlang_pspec
 
 type tbt_read (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:typ0) -> r:ref (elab_typ0 t) ->
-    ST (elab_typ0 t) All
+    ST (elab_typ0 t) AllOps
       (requires (fun h0 -> inv h0 /\ prref r))
       (ensures  (fun h0 v h1 -> h0 `hrel` h1 /\ inv h1 /\ (elab_typ0_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy v prref))
 
 type tbt_write (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:typ0) -> r:ref (elab_typ0 t) -> v:(elab_typ0 t) ->
-    ST unit All
+    ST unit AllOps
       (requires (fun h0 -> inv h0 /\ prref r /\ (elab_typ0_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy v prref))
       (ensures  (fun h0 _ h1 -> h0 `hrel` h1 /\ inv h1))
 
 type tbt_alloc (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:typ0) -> init:(elab_typ0 t) ->
-    ST (ref (elab_typ0 t)) All
+    ST (ref (elab_typ0 t)) AllOps
       (requires (fun h0 -> inv h0 /\ (elab_typ0_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy init prref))
       (ensures  (fun h0 r h1 -> h0 `hrel` h1 /\ inv h1 /\ prref r))
 
@@ -408,7 +408,7 @@ let rec backtranslate
   (#t:typ)
   (tyj:typing g e t)
   (ve:(vcontext (mk_targetlang_pspec inv prref hrel) g){all_refs_contained_and_low ve}) :
-  ST (elab_typ (mk_targetlang_pspec inv prref hrel) t) All
+  ST (elab_typ (mk_targetlang_pspec inv prref hrel) t) AllOps
     (fun h0 -> inv h0)
     (fun h0 r h1 -> inv h1 /\ h0 `hrel` h1 /\ (elab_typ_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy r prref)
     (decreases %[e;1])

--- a/state/Backtranslation.STLCToTargetLang.fst
+++ b/state/Backtranslation.STLCToTargetLang.fst
@@ -75,19 +75,19 @@ let mk_targetlang_pspec
 
 type tbt_read (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:typ0) -> r:ref (elab_typ0 t) ->
-    ST (elab_typ0 t) AllOps
+    ST (elab_typ0 t)
       (requires (fun h0 -> inv h0 /\ prref r))
       (ensures  (fun h0 v h1 -> h0 `hrel` h1 /\ inv h1 /\ (elab_typ0_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy v prref))
 
 type tbt_write (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:typ0) -> r:ref (elab_typ0 t) -> v:(elab_typ0 t) ->
-    ST unit AllOps
+    ST unit
       (requires (fun h0 -> inv h0 /\ prref r /\ (elab_typ0_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy v prref))
       (ensures  (fun h0 _ h1 -> h0 `hrel` h1 /\ inv h1))
 
 type tbt_alloc (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:typ0) -> init:(elab_typ0 t) ->
-    ST (ref (elab_typ0 t)) AllOps
+    ST (ref (elab_typ0 t))
       (requires (fun h0 -> inv h0 /\ (elab_typ0_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy init prref))
       (ensures  (fun h0 r h1 -> h0 `hrel` h1 /\ inv h1 /\ prref r))
 
@@ -408,7 +408,7 @@ let rec backtranslate
   (#t:typ)
   (tyj:typing g e t)
   (ve:(vcontext (mk_targetlang_pspec inv prref hrel) g){all_refs_contained_and_low ve}) :
-  ST (elab_typ (mk_targetlang_pspec inv prref hrel) t) AllOps
+  ST (elab_typ (mk_targetlang_pspec inv prref hrel) t)
     (fun h0 -> inv h0)
     (fun h0 r h1 -> inv h1 /\ h0 `hrel` h1 /\ (elab_typ_tc #(mk_targetlang_pspec inv prref hrel) t).wt.satisfy r prref)
     (decreases %[e;1])

--- a/state/Compiler.fst
+++ b/state/Compiler.fst
@@ -155,7 +155,7 @@ type ctx_tgt2 (i:tgt_interface2) =
   write : ttl_write fl inv prref hrel ->
   alloc : ttl_alloc fl inv prref hrel  ->
   p:i.pt fl inv prref hrel ->
-  ST int fl (fun h0 -> inv h0) (fun h0 _ h1 -> h0 `hrel` h1 /\ inv h1) (** TODO: to check if the program should be an arrow because we don't enforce prref **)
+  STFlag int fl (fun h0 -> inv h0) (fun h0 _ h1 -> h0 `hrel` h1 /\ inv h1) (** TODO: to check if the program should be an arrow because we don't enforce prref **)
 
 type prog_tgt2 (i:tgt_interface2) =
   i.pt AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)

--- a/state/Compiler.fst
+++ b/state/Compiler.fst
@@ -38,7 +38,7 @@ let src_language1 : language (st_wp int) = {
 noeq
 type tgt_interface1 = {
   ct : fl:_ -> inv : (heap -> Type0) -> prref: mref_pred -> hrel : FStar.Preorder.preorder heap -> Type u#a;
-  c_ct : targetlang default_spec (ct All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec));
+  c_ct : targetlang default_spec (ct AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec));
 }
 
 type ctx_tgt1 (i:tgt_interface1) =
@@ -53,12 +53,12 @@ type ctx_tgt1 (i:tgt_interface1) =
   i.ct fl inv prref hrel
 
 type prog_tgt1 (i:tgt_interface1) =
-  i.ct All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec) ->
+  i.ct AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec) ->
   SST int (fun _ -> True) (fun _ _ _ -> True)
 
 type whole_tgt1 = (unit -> SST int (fun _ -> True) (fun _ _ _ -> True))
 
-val instantiate_ctx_tgt1 : (#i:tgt_interface1) -> ctx_tgt1 i -> i.ct All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
+val instantiate_ctx_tgt1 : (#i:tgt_interface1) -> ctx_tgt1 i -> i.ct AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
 let instantiate_ctx_tgt1 c =
   c (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec) tl_read tl_write tl_alloc
 
@@ -123,7 +123,7 @@ type ctx_src2 (i:src_interface2) =
   i.pt ->
   SST int (fun h0 -> True) (fun h0 _ h1 -> (Mktuple3?._3 default_spec) h0 h1)
 
-type prog_src2 (i:src_interface2) = i.pt 
+type prog_src2 (i:src_interface2) = i.pt
 type whole_src2 = unit -> SST int (fun h0 -> True) (fun h0 _ h1 -> (Mktuple3?._3 default_spec) h0 h1)
 
 let link_src2 (#i:src_interface2) (p:prog_src2 i) (c:ctx_src2 i) : whole_src2 =
@@ -142,7 +142,7 @@ let src_language2 : language (st_wp int) = {
 noeq
 type tgt_interface2 = {
   pt : fl:_ -> inv : (heap -> Type0) -> prref: mref_pred -> hrel : FStar.Preorder.preorder heap -> Type u#a;
-  c_pt : targetlang default_spec (pt All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec));
+  c_pt : targetlang default_spec (pt AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec));
 }
 
 type ctx_tgt2 (i:tgt_interface2) =
@@ -158,7 +158,7 @@ type ctx_tgt2 (i:tgt_interface2) =
   ST int fl (fun h0 -> inv h0) (fun h0 _ h1 -> h0 `hrel` h1 /\ inv h1) (** TODO: to check if the program should be an arrow because we don't enforce prref **)
 
 type prog_tgt2 (i:tgt_interface2) =
-  i.pt All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
+  i.pt AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
 
 type whole_tgt2 = (unit -> SST int (fun h0 -> True) (fun h0 _ h1 -> (Mktuple3?._3 default_spec) h0 h1))
 
@@ -186,7 +186,7 @@ let comp_int_src_tgt2 (i:src_interface2) : tgt_interface2 = {
 
 val backtranslate_ctx2 : (#i:src_interface2) -> ctx_tgt2 (comp_int_src_tgt2 i) -> src_language2.ctx i
 let backtranslate_ctx2 #i ct ps =
-  ct #All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
+  ct #AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
       tl_read tl_write tl_alloc (i.c_pt.export ps)
 
 val compile_pprog2 : (#i:src_interface2) -> prog_src2 i -> prog_tgt2 (comp_int_src_tgt2 i)

--- a/state/Examples.fst
+++ b/state/Examples.fst
@@ -3,8 +3,8 @@ module Examples
 open FStar.Preorder
 open SharedRefs
 open Witnessable
-  
-type grade = 
+
+type grade =
 | NotGraded
 | MaxGrade
 | MinGrade
@@ -26,11 +26,11 @@ let sorted (ll:linkedList int) (h:heap) = admit ()
 let same_elements (ll:linkedList int) (h0 h1:heap) = admit ()
 
 type student_solution =
-  ll:linkedList int -> SST (option unit) 
-    (requires (fun h0 -> 
+  ll:linkedList int -> SST (option unit)
+    (requires (fun h0 ->
       no_cycles ll h0 /\
       forall_refs_heap contains_pred h0 #(SLList SNat) ll /\ forall_refs_heap is_shared h0 #(SLList SNat) ll))
-    (ensures (fun h0 r h1 -> 
+    (ensures (fun h0 r h1 ->
       (Some? r ==> no_cycles ll h1 /\ sorted ll h1 /\ same_elements ll h0 h1) /\
       modifies_only_shared h0 h1 /\ gets_shared Set.empty h0 h1))
 
@@ -44,10 +44,10 @@ let rec grading_done (sts: list (mref grade grade_preorder * student_solution)) 
 let generate_llist (l:list int) : SST (linkedList int) (fun h0 -> True) (fun h0 r h1 -> True) = admit () (** not sure what specs are needed here **)
 let share_llist (l:linkedList int) : SST unit (fun h0 -> True) (fun h0 r h1 -> True) = admit () (** not sure what specs are needed here **)
 
-let rec auto_grader 
+let rec auto_grader
   (l:list int)
   (sts: list (mref grade grade_preorder * student_solution))
-  : SST unit 
+  : SST unit
     (requires (fun h0 -> wss.satisfy_on_heap sts h0 (fun r h0 -> ~(is_shared r h0))))
     (ensures (fun h0 () h1 ->
       wss.satisfy_on_heap sts h1 (fun r h0 -> ~(is_shared r h0)) /\
@@ -61,6 +61,6 @@ let rec auto_grader
     admit ();
     (match hw ll with
     | Some _ -> sst_write'' gr MaxGrade
-    | None -> sst_write'' gr MinGrade);
+    | NoOps -> sst_write'' gr MinGrade);
     auto_grader l tl
   end

--- a/state/HigherOrderContracts.fst
+++ b/state/HigherOrderContracts.fst
@@ -138,14 +138,14 @@ instance exportable_arrow
   (pre:(t1 -> st_pre))
   (post:(x:t1 -> h0:heap -> st_post' (resexn t2) (pre x h0)))
   (_:squash (forall x h0 r h1. post x h0 r h1 ==> post_targetlang_arrow default_spec #(resexn t2) #(witnessable_sum t2 err #c2.c_styp) h0 r h1))
-  (check:(x:t1 -> ST (either unit err) AllOps (pre_targetlang_arrow default_spec #_ #c1.c_styp x) (fun h0 r h1 -> h0==h1 /\ (Inl? r ==> pre x h0))))
+  (check:(x:t1 -> ST (either unit err) (pre_targetlang_arrow default_spec #_ #c1.c_styp x) (fun h0 r h1 -> h0==h1 /\ (Inl? r ==> pre x h0))))
                              (** ^ the fact that the check has a pre-condition means that the check does not have to enforce it
                                  e.g., the invariant on the heap **)
-  : exportable_from (x:t1 -> ST (resexn t2) AllOps (pre x) (post x)) = {
+  : exportable_from (x:t1 -> ST (resexn t2) (pre x) (post x)) = {
   c_styp = witnessable_arrow t1 (resexn t2) pre post;
   ityp = mk_targetlang_arrow default_spec c1.ityp #c1.c_ityp.wt (resexn c2.ityp) #(witnessable_sum c2.ityp err #c2.c_ityp.wt);
   c_ityp = targetlang_arrow default_spec c1.ityp (resexn c2.ityp) #_ #(targetlang_sum default_spec c2.ityp err) ;
-  export = (fun (f:(x:t1 -> ST (resexn t2) AllOps (pre x) (post x))) (x:c1.ityp) ->
+  export = (fun (f:(x:t1 -> ST (resexn t2) (pre x) (post x))) (x:c1.ityp) ->
     match c1.import x with
     | Inl x' -> begin
       c1.lemma_import_preserves_prref x;
@@ -280,7 +280,7 @@ type cb_capture_check (t1:Type) (t2:Type) {| c2: witnessable t2 |}
   (post:(x:t1 -> h0:heap -> st_post' t2 (pre x h0)))
   (x:t1)
   (eh0:FStar.Ghost.erased heap{pre x eh0}) =
-  (r:t2 -> ST (resexn unit) AllOps (fun h1 -> post_targetlang_arrow default_spec eh0 r h1) (fun h1 rck h1' ->
+  (r:t2 -> ST (resexn unit) (fun h1 -> post_targetlang_arrow default_spec eh0 r h1) (fun h1 rck h1' ->
     h1 == h1' /\ (Inl? rck ==> post x eh0 r h1)))
 
 type capture_check
@@ -289,7 +289,7 @@ type capture_check
   (post:(x:t1 -> h0:heap -> st_post' t2 (pre x h0))) =
   x:t1 -> ST (
     eh0:FStar.Ghost.erased heap{pre x eh0} & cb_capture_check t1 t2 #c2 pre post x eh0
-  ) AllOps (pre x) (fun h0 r h1 -> FStar.Ghost.reveal (dfst r) == h0 /\ h0 == h1)
+  ) (pre x) (fun h0 r h1 -> FStar.Ghost.reveal (dfst r) == h0 /\ h0 == h1)
 
 instance safe_importable_arrow
   (t1:Type) (t2:Type)
@@ -300,7 +300,7 @@ instance safe_importable_arrow
   (_:squash (forall (x:t1) h0. pre x h0 ==> pre_targetlang_arrow default_spec #_ #c1.c_styp x h0))
   (_:squash (forall (x:t1) h0 e h1. pre x h0 /\ post_targetlang_arrow default_spec #_ #(witnessable_sum t2 err #c2.c_styp) h0 (Inr e) h1 ==> post x h0 (Inr e) h1))
   (capture_check:capture_check t1 (resexn t2) #(witnessable_sum _ err #c2.c_styp) pre post)
-  : safe_importable_to (x:t1 -> ST (resexn t2) AllOps (pre x) (post x)) = {
+  : safe_importable_to (x:t1 -> ST (resexn t2) (pre x) (post x)) = {
   c_styp = witnessable_arrow t1 (resexn t2) pre post;
   ityp = mk_targetlang_arrow default_spec c1.ityp #c1.c_ityp.wt (resexn c2.ityp) #(witnessable_sum c2.ityp err #c2.c_ityp.wt);
   c_ityp = targetlang_arrow default_spec c1.ityp (resexn c2.ityp) #_ #(targetlang_sum default_spec c2.ityp err #c2.c_ityp);

--- a/state/STLC.fst
+++ b/state/STLC.fst
@@ -46,7 +46,7 @@ type typ = t:unsafe_typ{good_univs t}
 let rec lemma_typ0_is_typ (t:typ0) :
      Lemma
           (requires True)
-          (ensures (good_univs t)) 
+          (ensures (good_univs t))
           [SMTPat (good_univs t)]
 = match t with
                | TUnit -> ()
@@ -198,12 +198,12 @@ noeq type typing : context -> exp -> typ -> Type0 =
    2) the structure of the expression e *)
 
 (* Parallel substitution operation `subst` *)
-let sub (renaming:bool) = 
+let sub (renaming:bool) =
     f:(var -> exp){ renaming <==> (forall x. EVar? (f x)) }
 
 let bool_order (b:bool) = if b then 0 else 1
 
-let sub_inc 
+let sub_inc
   : sub true
   = fun y -> EVar (y+1)
 
@@ -213,10 +213,10 @@ let rec subst (#r:bool)
               (s:sub r)
               (e:exp)
   : Tot (e':exp { r ==> (EVar? e <==> EVar? e') })
-        (decreases %[bool_order (EVar? e); 
+        (decreases %[bool_order (EVar? e);
                      bool_order r;
                      1;
-                     e]) = 
+                     e]) =
      match e with
      | EVar x -> s x
      | ELoc l -> ELoc l
@@ -235,23 +235,23 @@ let rec subst (#r:bool)
      | EReadRef e -> EReadRef (subst s e)
      | EWriteRef e1 e2 -> EWriteRef (subst s e1) (subst s e2)
 
-and sub_EAbs (#r:bool) (s:sub r) 
+and sub_EAbs (#r:bool) (s:sub r)
   : Tot (sub r)
         (decreases %[1;
                      bool_order r;
                      0;
                      EVar 0])
-  = let f : var -> exp = 
+  = let f : var -> exp =
       fun y ->
         if y=0
         then EVar y
         else subst sub_inc (s (y - 1))
     in
     introduce not r ==> (exists x. ~ (EVar? (f x)))
-    with not_r. 
+    with not_r.
       eliminate exists y. ~ (EVar? (s y))
       returns (exists x. ~ (EVar? (f x)))
-      with (not_evar_sy:squash (~(EVar? (s y)))). 
+      with (not_evar_sy:squash (~(EVar? (s y)))).
         introduce exists x. ~(EVar? (f x))
         with (y + 1)
         and ()
@@ -260,7 +260,7 @@ and sub_EAbs (#r:bool) (s:sub r)
 
 let sub_beta (e:exp)
   : sub (EVar? e)
-  = let f = 
+  = let f =
       fun (y:var) ->
         if y = 0 then e      (* substitute *)
         else (EVar (y-1))    (* shift -1 *)
@@ -290,14 +290,14 @@ let rec is_closed_exp (e:exp) (g:context) : bool =
      | EZero -> true
      | ELoc _ -> false // TODO: is this ok?
 
-let rec is_closed_value (e:exp) : bool = 
+let rec is_closed_value (e:exp) : bool =
      match e with
      | EUnit
      | EZero -> true
      | ESucc e -> is_closed_value e
      | ELoc _ -> false
      | EInl e -> is_closed_value e
-     | EInr e -> is_closed_value e 
+     | EInr e -> is_closed_value e
      | EPair e1 e2 -> is_closed_value e1 && is_closed_value e2
      | EAbs t _ -> is_closed_exp e (extend t empty)
      | _ -> false
@@ -399,7 +399,7 @@ type pure_step : exp -> exp -> Type =
 
 let store = loc -> option (e:exp{is_closed_value e})
 let empty_store : store = fun _ -> None
-let salloc (s:store) (l:loc) (v:exp{is_closed_value v}) : store = 
+let salloc (s:store) (l:loc) (v:exp{is_closed_value v}) : store =
      fun l' -> if l' = l then Some v else s l'
 
 noeq
@@ -459,7 +459,7 @@ let ctx_update_ref_test : typing empty _ (TArr (TRef TNat) TUnit) =
      TyAbs (TRef TNat) (TyWriteRef (TyVar 0) (TySucc (TyReadRef (TyVar 0))))
 
 let ctx_update_multiple_refs_test : typing empty _ (TArr (TRef (TRef TNat)) (TArr (TRef TNat) TUnit)) =
-     TyAbs (TRef (TRef TNat)) 
+     TyAbs (TRef (TRef TNat))
           (TyAbs (TRef TNat) (
                TyApp (TyAbs TUnit (TyWriteRef (TyVar 2) (TyVar 1)))
                      (TyWriteRef (TyVar 0) (TySucc (TyReadRef (TyVar 0))))))
@@ -471,7 +471,7 @@ let ctx_dynamic_alloc_test : typing empty _ (TArr TNat (TRef TNat)) =
      TyAbs TNat (TyAllocRef (TyVar 0))
 
 let ctx_returns_callback_test : typing empty _ (TArr TUnit (TArr TUnit TUnit)) =
-     TyAbs TUnit 
+     TyAbs TUnit
           (TyApp (TyAbs (TRef TNat) (TyAbs TUnit (TyWriteRef (TyVar 1) (TySucc (TyReadRef (TyVar 1))))))
                  (TyAllocRef TyZero))
 
@@ -483,7 +483,7 @@ let landins_knot : exp =
                (EApp
                  (EAbs (TArr TUnit TUnit) (* f *)
                     (EApp
-                         (EAbs TUnit (EApp (EVar 1) EUnit)) (* f () *)  
+                         (EAbs TUnit (EApp (EVar 1) EUnit)) (* f () *)
                          (EWriteRef (EVar 1) (EVar 0)) (* r := f *)
                     ))
                  (EAbs TUnit (EApp (EReadRef (EVar 1)) EUnit)))) (* f = fun () -> r () *)
@@ -491,16 +491,16 @@ let landins_knot : exp =
 
 let ty_landins_knot : typing empty landins_knot TUnit =
      TyApp (TyAbs (TRef (TArr TUnit TUnit))
-                  (TyApp (TyAbs (TArr TUnit TUnit) 
+                  (TyApp (TyAbs (TArr TUnit TUnit)
                                (TyApp (TyAbs TUnit (TyApp (TyVar 1) TyUnit))
                                        (TyWriteRef (TyVar 1) (TyVar 0))))
                          (TyAbs TUnit (TyApp (TyReadRef (TyVar 1)) TyUnit))))
            (TyAllocRef (TyAbs TUnit (TyVar 0)))
 **)
 
-open FStar.ST 
+open FStar.ST
 
-let landins_knot_fs () : St nat = 
+let landins_knot_fs () : St nat =
   let id : nat -> St nat = fun x -> x in
   let r : ref (nat -> St nat) = alloc id in
   let f : nat -> St nat = (fun x -> !r x) in

--- a/state/ShareableType.fst
+++ b/state/ShareableType.fst
@@ -83,7 +83,7 @@ let rec forall_refs_heap_monotonic (pred:mref_heap_stable_pred) (h0 h1:heap) (#t
    end
 
 let rec lemma_forall_refs_heap_forall_refs_witnessed #t (v:to_Type t) (pred:mref_heap_stable_pred) :
-  ST unit AllOps
+  ST unit
     (requires (fun h0 -> forall_refs_heap pred h0 v))
     (ensures (fun h0 _ h1 -> h0 == h1 /\ forall_refs (fun r -> witnessed (pred r)) v)) =
   match t with
@@ -113,7 +113,7 @@ let rec lemma_forall_refs_heap_forall_refs_witnessed #t (v:to_Type t) (pred:mref
   end
 
 let rec lemma_forall_refs_witnessed_forall_refs_heap #t (v:to_Type t) (pred:mref_heap_stable_pred) :
-  ST unit AllOps
+  ST unit
     (requires (fun _ -> forall_refs (fun r -> witnessed (pred r)) v))
     (ensures (fun h0 _ h1 -> h0 == h1 /\ forall_refs_heap pred h1 v)) =
   match t with

--- a/state/ShareableType.fst
+++ b/state/ShareableType.fst
@@ -83,7 +83,7 @@ let rec forall_refs_heap_monotonic (pred:mref_heap_stable_pred) (h0 h1:heap) (#t
    end
 
 let rec lemma_forall_refs_heap_forall_refs_witnessed #t (v:to_Type t) (pred:mref_heap_stable_pred) :
-  ST unit All
+  ST unit AllOps
     (requires (fun h0 -> forall_refs_heap pred h0 v))
     (ensures (fun h0 _ h1 -> h0 == h1 /\ forall_refs (fun r -> witnessed (pred r)) v)) =
   match t with
@@ -113,7 +113,7 @@ let rec lemma_forall_refs_heap_forall_refs_witnessed #t (v:to_Type t) (pred:mref
   end
 
 let rec lemma_forall_refs_witnessed_forall_refs_heap #t (v:to_Type t) (pred:mref_heap_stable_pred) :
-  ST unit All
+  ST unit AllOps
     (requires (fun _ -> forall_refs (fun r -> witnessed (pred r)) v))
     (ensures (fun h0 _ h1 -> h0 == h1 /\ forall_refs_heap pred h1 v)) =
   match t with

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -54,7 +54,7 @@ let share_post (map_shared:map_sharedT) (is_shared:mref_heap_stable_pred) #a #re
     gets_shared !{sr} h0 h1
 
 val share : #a:Type0 -> #p:preorder a -> sr:(mref a p) ->
-    ST unit AllOps
+    ST unit
       (requires (fun h0 ->
         h0 `contains` sr /\
         h0 `contains` map_shared /\
@@ -127,7 +127,7 @@ let sst_post
     post h0 r h1
 
 effect SST (a:Type) (pre:st_pre) (post: (h:heap -> Tot (st_post' a ((sst_pre pre) h)))) =
-  ST a AllOps
+  ST a
     (requires (sst_pre pre))
     (ensures  (sst_post a pre post))
 

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -54,7 +54,7 @@ let share_post (map_shared:map_sharedT) (is_shared:mref_heap_stable_pred) #a #re
     gets_shared !{sr} h0 h1
 
 val share : #a:Type0 -> #p:preorder a -> sr:(mref a p) ->
-    ST unit All
+    ST unit AllOps
       (requires (fun h0 ->
         h0 `contains` sr /\
         h0 `contains` map_shared /\
@@ -127,7 +127,7 @@ let sst_post
     post h0 r h1
 
 effect SST (a:Type) (pre:st_pre) (post: (h:heap -> Tot (st_post' a ((sst_pre pre) h)))) =
-  ST a All
+  ST a AllOps
     (requires (sst_pre pre))
     (ensures  (sst_post a pre post))
 

--- a/state/TargetLang.fst
+++ b/state/TargetLang.fst
@@ -50,7 +50,7 @@ let mk_targetlang_arrow
   (pspec:targetlang_pspec)
   (t1:Type) {| c1 : witnessable t1 |}
   (t2:Type) {| c2 : witnessable t2 |}
-= x:t1 -> ST t2 AllOps
+= x:t1 -> ST t2
     (pre_targetlang_arrow pspec x)
     (post_targetlang_arrow pspec)
 
@@ -70,19 +70,19 @@ let default_spec : targetlang_pspec = (
 
 type ttl_read (fl : erased tflag) (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:shareable_typ) -> r:ref (to_Type t) ->
-    ST (to_Type t) fl
+    STFlag (to_Type t) fl
       (requires (fun h0 -> inv h0 /\ prref r))
       (ensures  (fun h0 v h1 -> h0 `hrel` h1 /\ inv h1 /\ forall_refs prref v))
 
 type ttl_write (fl : erased tflag) (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:shareable_typ) -> r:ref (to_Type t) -> v:(to_Type t) ->
-    ST unit fl
+    STFlag unit fl
       (requires (fun h0 -> inv h0 /\ prref r /\ forall_refs prref v))
       (ensures  (fun h0 _ h1 -> h0 `hrel` h1 /\ inv h1))
 
 type ttl_alloc (fl : erased tflag) (inv:heap -> Type0) (prref:mref_pred) (hrel:FStar.Preorder.preorder heap) =
   (#t:shareable_typ) -> init:(to_Type t) ->
-    ST (ref (to_Type t)) fl
+    STFlag (ref (to_Type t)) fl
       (requires (fun h0 -> inv h0 /\ forall_refs prref init))
       (ensures  (fun h0 r h1 -> h0 `hrel` h1 /\ inv h1 /\ prref r))
 

--- a/state/TargetLang.fst
+++ b/state/TargetLang.fst
@@ -50,7 +50,7 @@ let mk_targetlang_arrow
   (pspec:targetlang_pspec)
   (t1:Type) {| c1 : witnessable t1 |}
   (t2:Type) {| c2 : witnessable t2 |}
-= x:t1 -> ST t2 All
+= x:t1 -> ST t2 AllOps
     (pre_targetlang_arrow pspec x)
     (post_targetlang_arrow pspec)
 
@@ -86,7 +86,7 @@ type ttl_alloc (fl : erased tflag) (inv:heap -> Type0) (prref:mref_pred) (hrel:F
       (requires (fun h0 -> inv h0 /\ forall_refs prref init))
       (ensures  (fun h0 r h1 -> h0 `hrel` h1 /\ inv h1 /\ prref r))
 
-val tl_read : ttl_read All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
+val tl_read : ttl_read AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
 let tl_read #t r =
   let h0 = get_heap () in
   recall (contains_pred r);
@@ -99,7 +99,7 @@ let tl_read #t r =
   lemma_forall_refs_join v (fun r -> witnessed (contains_pred r)) (fun r -> witnessed (is_shared r));
   v
 
-val tl_write : ttl_write All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
+val tl_write : ttl_write AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
 let tl_write #t r v =
   recall (contains_pred r);
   recall (is_shared r);
@@ -116,7 +116,7 @@ let tl_write #t r v =
   assert (~(is_shared (map_shared) h1));
   assert ((forall p. p >= next_addr h1 ==> ~(sel h1 map_shared p)))
 
-val tl_alloc : ttl_alloc All (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
+val tl_alloc : ttl_alloc AllOps (Mktuple3?._1 default_spec) (Mktuple3?._2 default_spec) (Mktuple3?._3 default_spec)
 let tl_alloc #t init =
   assert (forall_refs (fun r' -> witnessed (contains_pred r') /\ witnessed (is_shared r')) init);
   lemma_forall_refs_split init (fun r -> witnessed (contains_pred r)) (fun r -> witnessed (is_shared r));

--- a/state/Witnessable.fst
+++ b/state/Witnessable.fst
@@ -17,7 +17,7 @@ class witnessable (t:Type) = {
     Lemma (requires (h0 `heap_rel` h1 /\ satisfy_on_heap x h0 pred))
           (ensures (satisfy_on_heap x h1 pred));
 
-  pwitness : x:t -> pred:mref_heap_stable_pred -> ST (precall:(unit -> ST unit AllOps (fun _ -> True) (fun h0 _ h1 -> h0 == h1 /\ satisfy_on_heap x h1 pred))) AllOps
+  pwitness : x:t -> pred:mref_heap_stable_pred -> ST (precall:(unit -> ST unit (fun _ -> True) (fun h0 _ h1 -> h0 == h1 /\ satisfy_on_heap x h1 pred)))
     (requires (fun h0 -> satisfy_on_heap x h0 pred))
     (ensures (fun h0 _ h1 -> h0 == h1));
 }
@@ -56,7 +56,7 @@ instance witnessable_arrow
   (t1:Type) (t2:Type)
   (pre:t1 -> st_pre)
   (post:(x:t1 -> h0:heap -> st_post' t2 (pre x h0))) // TODO: one cannot have pre-post depending on outside things.
-: witnessable (x:t1 -> ST t2 AllOps (pre x) (post x)) = {
+: witnessable (x:t1 -> ST t2 (pre x) (post x)) = {
   satisfy = (fun _ _ -> True);
   satisfy_on_heap = (fun _ _ _ -> True);
   satisfy_on_heap_monotonic = (fun _ _ _ _ -> ());

--- a/state/Witnessable.fst
+++ b/state/Witnessable.fst
@@ -17,7 +17,7 @@ class witnessable (t:Type) = {
     Lemma (requires (h0 `heap_rel` h1 /\ satisfy_on_heap x h0 pred))
           (ensures (satisfy_on_heap x h1 pred));
 
-  pwitness : x:t -> pred:mref_heap_stable_pred -> ST (precall:(unit -> ST unit All (fun _ -> True) (fun h0 _ h1 -> h0 == h1 /\ satisfy_on_heap x h1 pred))) All
+  pwitness : x:t -> pred:mref_heap_stable_pred -> ST (precall:(unit -> ST unit AllOps (fun _ -> True) (fun h0 _ h1 -> h0 == h1 /\ satisfy_on_heap x h1 pred))) AllOps
     (requires (fun h0 -> satisfy_on_heap x h0 pred))
     (ensures (fun h0 _ h1 -> h0 == h1));
 }
@@ -56,7 +56,7 @@ instance witnessable_arrow
   (t1:Type) (t2:Type)
   (pre:t1 -> st_pre)
   (post:(x:t1 -> h0:heap -> st_post' t2 (pre x h0))) // TODO: one cannot have pre-post depending on outside things.
-: witnessable (x:t1 -> ST t2 All (pre x) (post x)) = {
+: witnessable (x:t1 -> ST t2 AllOps (pre x) (post x)) = {
   satisfy = (fun _ _ -> True);
   satisfy_on_heap = (fun _ _ _ -> True);
   satisfy_on_heap_monotonic = (fun _ _ _ _ -> ());
@@ -66,20 +66,20 @@ instance witnessable_arrow
 instance witnessable_option (t:Type) {| c:witnessable t |} : witnessable (option t) = {
   satisfy = (fun x pred ->
     match x with
-    | FStar.Pervasives.Native.None -> True
+    | None -> True
     | Some x' -> c.satisfy x' pred);
   satisfy_on_heap = (fun x h pred ->
     match x with
-    | FStar.Pervasives.Native.None -> True
+    | None -> True
     | Some x' -> c.satisfy_on_heap x' h pred);
   satisfy_on_heap_monotonic = (fun x pred h0 h1 ->
     match x with
-    | FStar.Pervasives.Native.None -> ()
+    | None -> ()
     | Some x' -> c.satisfy_on_heap_monotonic x' pred h0 h1);
   pwitness = (fun x pred ->
     match x with
-    | FStar.Pervasives.Native.None -> (fun () -> ())
-    | Some x' -> 
+    | None -> (fun () -> ())
+    | Some x' ->
       let w = c.pwitness x' pred in (fun () -> w ()))
 }
 


### PR DESCRIPTION
And `ST` is now a shorthand for `STFlag` with `AllOps`.