### PR TITLE
Adding encapsulated references

### DIFF
--- a/state/Backtranslation.STLCToTargetLang.fst
+++ b/state/Backtranslation.STLCToTargetLang.fst
@@ -209,7 +209,7 @@ val progr_declassify :
   SST unit
     (requires (fun h0 ->
       satisfy_on_heap rp h0 contains_pred /\
-      ~(is_shared rp h0)))
+      is_private rp h0))
     (ensures (fun h0 _ h1 -> True))
 let progr_declassify rp f =
   sst_share #SNat rp;
@@ -223,7 +223,8 @@ val progr_declassify_nested:
   SST unit
     (requires (fun h0 ->
       satisfy_on_heap rp h0 contains_pred /\
-      ~(is_shared rp h0)))
+      is_private rp h0 /\
+      is_private (sel h0 rp) h0))
     (ensures (fun h0 _ h1 -> True))
 let progr_declassify_nested rp f =
   let p : ref int = sst_read #(SRef SNat) rp in

--- a/state/Backtranslation.STLCToTargetLang.fst
+++ b/state/Backtranslation.STLCToTargetLang.fst
@@ -251,7 +251,7 @@ let progr_secret_unchanged_test rp rs ctx =
   let v = sst_read #SNat secret in
   ()
 
-val progr_passing_callback_test:
+val progr_passing_shared_to_callback_test:
   rp: ref int ->
   rs: ref (ref int) ->
   ctx:(elab_typ default_spec (TArr (TArr TUnit TUnit) TUnit)) ->
@@ -261,8 +261,8 @@ val progr_passing_callback_test:
       is_private rp h0 /\
       satisfy_on_heap rs h0 is_shared))
     (ensures (fun h0 _ h1 -> sel h0 rp == sel h1 rp)) // the content of rp should stay the same before/ after calling the context
-// TODO: the callback of the program should be able to modify rp
-let progr_passing_callback_test rp rs f =
+// TODO: the callback of the program should be able to modify rp (DA: now the callbacks can modify encapsulated, not private references)
+let progr_passing_shared_to_callback_test rp rs f =
   let secret: ref int = sst_alloc #SNat 0 in
   sst_share #SNat secret;
   witness (contains_pred secret); witness (is_shared secret);
@@ -273,7 +273,7 @@ let progr_passing_callback_test rp rs f =
   downgrade_val (f cb);
   ()
 
-val progr_passing_callback_test':
+val progr_passing_encapsulated_to_callback_test:
   rp: ref int ->
   rs: ref (ref int) ->
   ctx:(elab_typ default_spec (TArr (TArr TUnit TUnit) TUnit)) ->
@@ -283,8 +283,7 @@ val progr_passing_callback_test':
       is_private rp h0 /\
       satisfy_on_heap rs h0 is_shared))
     (ensures (fun h0 _ h1 -> sel h0 rp == sel h1 rp)) // the content of rp should stay the same before/ after calling the context
-// TODO: the callback of the program should be able to modify rp
-let progr_passing_callback_test' rp rs f =
+let progr_passing_encapsulated_to_callback_test rp rs f =
   let secret: ref int = sst_alloc #SNat 0 in
   sst_encapsulate secret;
   witness (contains_pred secret); witness (is_encapsulated secret);

--- a/state/SharedRefs.fst
+++ b/state/SharedRefs.fst
@@ -36,3 +36,13 @@ let lemma_unmodified_map_implies_same_shared_status (ms:Set.set nat) (h0 h1:heap
     end
     
 let lemma_same_addr_same_sharing_status = (fun ra rb h -> ())
+
+let encapsulate = (fun #a #p r ->
+    let h0 = get_heap () in
+    lemma_next_addr_contained_refs_addr h0 r ;
+    let m = !secret_map in
+    let m' = (fun p -> if p = addr_of r then Encapsulated else m p) in
+    secret_map := m';
+    let h1 = get_heap () in
+    lemma_next_addr_upd h0 secret_map m'
+  )

--- a/state/SharedRefs.fst
+++ b/state/SharedRefs.fst
@@ -17,7 +17,7 @@ let share = (fun #a #p sr ->
     let h0 = get_heap () in
     lemma_next_addr_contained_refs_addr h0 sr ;
     let m = !secret_map in
-    let m' = (fun p -> if p = addr_of sr then true else m p) in
+    let m' = (fun p -> if p = addr_of sr then Shared else m p) in
     secret_map := m';
     let h1 = get_heap () in
     lemma_next_addr_upd h0 secret_map m'
@@ -34,5 +34,5 @@ let lemma_unmodified_map_implies_same_shared_status (ms:Set.set nat) (h0 h1:heap
         introduce is_shared r h1 ==> is_shared r h0 with _. ()
       end
     end
-
+    
 let lemma_same_addr_same_sharing_status = (fun ra rb h -> ())

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -441,7 +441,7 @@ let sst_alloc (#t:shareable_typ) (init:to_Type t)
     (fun h0 -> forall_refs_heap contains_pred h0 init)
     (fun h0 r h1 ->
       alloc_post #(to_Type t) init h0 r h1 /\
-      ~(is_shared r h1) /\
+      is_private r h1 /\
       gets_shared Set.empty h0 h1)
 =
   let h0 = get_heap () in
@@ -450,7 +450,7 @@ let sst_alloc (#t:shareable_typ) (init:to_Type t)
   lemma_fresh_ref_not_shared r h0;
   lemma_unmodified_map_implies_same_shared_status Set.empty h0 h1;
   lemma_upd_preserves_contains r init h0 h1;
-  assert (~(is_shared r h1));
+  assert (is_private r h1);
   lemma_sst_alloc_preserves_shared r init h0 h1;
   r
 
@@ -461,7 +461,7 @@ let sst_alloc' #a (#rel:preorder a) (init:a)
         forall_refs_heap contains_pred h0 #t init))
     (fun h0 r h1 ->
       alloc_post #a init h0 r h1 /\
-      ~(is_shared r h1) /\
+      is_private r h1 /\
       gets_shared Set.empty h0 h1)
 =
   let h0 = get_heap () in
@@ -470,7 +470,7 @@ let sst_alloc' #a (#rel:preorder a) (init:a)
   lemma_fresh_ref_not_shared r h0;
   lemma_unmodified_map_implies_same_shared_status Set.empty h0 h1;
   assert (gets_shared Set.empty h0 h1);
-  assert (~(is_shared r h1));
+  assert (is_private r h1);
   assert (alloc_post #a init h0 r h1);
   assert (ctrans_ref_pred h0 contains_pred);
   lemma_upd_preserves_contains_alloc' r init h0 h1;
@@ -715,7 +715,7 @@ let lemma_sst_encapsulate_preserves_shared #a (#rel:preorder a) (x:mref a rel) (
 #pop-options
   
 val encapsulate : #a:Type0 -> #p:preorder a -> r:(mref a p) ->
-    ST unit All
+    ST unit 
       (requires (fun h0 ->
         h0 `contains` r /\
         h0 `contains` map_shared /\

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -27,18 +27,37 @@ val lemma_eq_ref_types_eq_value_types #a #b (#rela:preorder a) (#relb : preorder
 let lemma_eq_ref_types_eq_value_types _ = ()
 *)
 
+type ref_kind =
+  | Private
+  | Shared
+  | Encapsulated
+
+let ref_kind_rel : preorder ref_kind = fun k k' ->
+  match k , k' with
+  | Private , _ -> True
+  | Shared , Shared -> True
+  | Encapsulated , Encapsulated -> True
+  | _ , _ -> False
+
 type map_sharedT =
   mref
-    (pos -> GTot bool)
-    (fun (m0 m1:(pos -> GTot bool)) ->
-      forall p. (m0 p) ==>  (m1 p))
-  (** pre-order necessary to show that the predicate `is_shared` is stable **)
+    (pos -> GTot ref_kind)
+    (fun (m0 m1:(pos -> GTot ref_kind)) ->
+      forall p. (m0 p) `ref_kind_rel`  (m1 p))
 
 val map_shared : erased map_sharedT
 
+let is_private : mref_heap_pred = (fun #a #p (r:mref a p) h ->
+    h `contains` map_shared /\ (** this contains is necessary to show that is_shared is a stable predicate **)
+    Private? ((sel h map_shared) (addr_of r)))
+
+let is_private_addr : pos -> heap -> Type0 = (fun p h ->
+    h `contains` map_shared /\ (** this contains is necessary to show that is_shared is a stable predicate **)
+    Private? ((sel h map_shared) p))
+
 let is_shared : mref_heap_stable_pred = (fun #a #p (r:mref a p) h ->
     h `contains` map_shared /\ (** this contains is necessary to show that is_shared is a stable predicate **)
-    (sel h map_shared) (addr_of r))
+    Shared? ((sel h map_shared) (addr_of r)))
 
 let gets_shared (s:set nat) (h0:heap) (h1:heap) =
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (is_shared r h1)}
@@ -49,8 +68,8 @@ let gets_shared (s:set nat) (h0:heap) (h1:heap) =
 let share_post (map_shared:map_sharedT) (is_shared:mref_heap_stable_pred) #a #rel (sr:mref a rel) h0 () h1 : Type0 =
     equal_dom h0 h1 /\
     modifies !{map_shared} h0 h1 /\
-    ~(is_shared (map_shared) h1) /\
-    (forall p. p >= next_addr h1 ==>  ~(sel h1 map_shared p)) /\
+    is_private (map_shared) h1 /\
+    (forall p. p >= next_addr h1 ==> is_private_addr p h1) /\
     gets_shared !{sr} h0 h1
 
 val share : #a:Type0 -> #p:preorder a -> sr:(mref a p) ->
@@ -59,17 +78,18 @@ val share : #a:Type0 -> #p:preorder a -> sr:(mref a p) ->
         h0 `contains` sr /\
         h0 `contains` map_shared /\
         ~(compare_addrs sr map_shared) /\ (** prevent sharing the map *)
-        ~(is_shared map_shared h0) /\
-        (forall p. p >= next_addr h0 ==> ~(sel h0 map_shared p)))) (** necessary to prove that freshly allocated references are not shared **)
+        is_private map_shared h0 /\
+        is_private sr h0 /\ (** necessary to change the reference kind to shared *)
+        (forall p. p >= next_addr h0 ==> is_private_addr p h0))) (** necessary to prove that freshly allocated references are not shared **)
       (ensures (share_post map_shared is_shared #a #p sr))
 
 val lemma_fresh_ref_not_shared : #a:_ -> #rel:_ -> (r:mref a rel) -> h:heap ->
-    Lemma (requires (forall p. p >= next_addr h ==> ~((sel h map_shared) p)) /\ (addr_of r >= next_addr h))
-          (ensures (~(is_shared r h)))
+    Lemma (requires (h `contains` map_shared /\ (forall p. p >= next_addr h ==> is_private_addr p h) /\ (addr_of r >= next_addr h)))
+          (ensures  (is_private r h))
 
 val lemma_unmodified_map_implies_same_shared_status : s:Set.set nat -> h0:heap -> h1:heap ->
     Lemma (requires (h0 `contains` map_shared /\ h0 `heap_rel` h1 /\ ~(addr_of map_shared `Set.mem` s) /\ modifies s h0 h1))
-          (ensures (gets_shared Set.empty h0 h1))
+          (ensures  (gets_shared Set.empty h0 h1))
 
 val lemma_same_addr_same_sharing_status : #aa:_ -> #rela:_ -> #b:_ -> #relb:_ -> ra:mref aa rela -> rb:mref b relb -> h:heap ->
     Lemma (requires (addr_of ra == addr_of rb))
@@ -87,7 +107,6 @@ let modifies_only_shared (h0:heap) (h1:heap) : Type0 =
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (sel h1 r)}
     (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0)) ==> sel h0 r == sel h1 r) /\
   unmodified_common h0 h1
-
 
 let ctrans_ref_pred (h:heap) (pred:mref_heap_stable_pred) =
   (** forall references, if r satisfies pred in h, then the references r points to refs that also satisfy pred **)
@@ -110,8 +129,8 @@ let sst_pre (pre:st_pre) : st_pre =
   fun h0 ->
     trans_shared_contains h0 /\
     h0 `contains` map_shared /\
-    ~(is_shared (map_shared) h0) /\ (* the map stays unshared *)
-    (forall p. p >= next_addr h0 ==> ~(sel h0 map_shared p)) /\
+    is_private (map_shared) h0 /\ (* the map stays unshared *)
+    (forall p. p >= next_addr h0 ==> is_private_addr p h0) /\
     pre h0
 
 unfold
@@ -122,8 +141,8 @@ let sst_post
   : (h:heap -> Tot (st_post' a ((sst_pre pre) h))) =
   fun h0 r h1 ->
     trans_shared_contains h1 /\
-    ~(is_shared (map_shared) h1) /\
-    (forall p. p >= next_addr h1 ==> ~(sel h1 map_shared p)) /\
+    is_private (map_shared) h1 /\
+    (forall p. p >= next_addr h1 ==> is_private_addr p h1) /\
     post h0 r h1
 
 effect SST (a:Type) (pre:st_pre) (post: (h:heap -> Tot (st_post' a ((sst_pre pre) h)))) =
@@ -377,7 +396,7 @@ let lemma_sst_share_preserves_shared #t (x:ref (to_Type t)) (h0 h1:heap) : Lemma
     h0 `contains` x /\
     forall_refs_heap is_shared h0 (sel h0 x) /\
     gets_shared !{x} h0 h1 /\
-    (forall p. p >= next_addr h1 ==> ~(sel h1 map_shared p)) /\
+    (forall p. p >= next_addr h1 ==> is_private_addr p h1) /\
     ctrans_ref_pred h0 is_shared))
   (ensures (
     ctrans_ref_pred h1 is_shared)) =
@@ -460,6 +479,7 @@ let sst_alloc' #a (#rel:preorder a) (init:a)
 let sst_share (#t:shareable_typ) (r:ref (to_Type t))
 : SST unit
   (fun h0 -> h0 `contains` r /\
+         is_private r h0 /\
          forall_refs_heap is_shared h0 (sel h0 r))
   (share_post map_shared is_shared r)
 =
@@ -522,7 +542,7 @@ let sst_write (#t:shareable_typ) (r:ref (to_Type t)) (v:to_Type t)
   assert (~(is_shared (map_shared) h1));
   lemma_next_addr_upd_tot h0 r v;
   assert (next_addr h0 == next_addr h1);
-  assert (forall p. p >= next_addr h1 ==> ~(sel h1 map_shared p));
+  assert (forall p. p >= next_addr h1 ==> is_private_addr p h1);
   assert (is_shared r h0 ==> modifies_only_shared h0 h1);
   ()
 #pop-options
@@ -592,7 +612,7 @@ let sst_write' #a (r:ref a) (v:a)
   let h1 = get_heap () in
   assert (~(is_shared (map_shared) h1));
   lemma_next_addr_upd h0 r v;
-  assert (forall p. p >= next_addr h1 ==> ~(sel h1 map_shared p));
+  assert (forall p. p >= next_addr h1 ==> is_private_addr p h1);
   lemma_upd_equals_upd_tot_for_contained_refs h0 r v;
   lemma_unmodified_map_implies_same_shared_status !{r} h0 h1;
   introduce (exists t. to_Type t == a) ==> trans_shared_contains h1 with _. begin
@@ -625,7 +645,7 @@ let sst_write'' #a (#rel:preorder a) (r:mref a rel) (v:a)
   let h1 = get_heap () in
   assert (~(is_shared (map_shared) h1));
   lemma_next_addr_upd h0 r v;
-  assert (forall p. p >= next_addr h1 ==> ~(sel h1 map_shared p));
+  assert (forall p. p >= next_addr h1 ==> is_private_addr p h1);
   lemma_upd_equals_upd_tot_for_contained_refs h0 r v;
   lemma_unmodified_map_implies_same_shared_status !{r} h0 h1;
   introduce (exists t. to_Type t == a) ==> trans_shared_contains h1 with _. begin

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -62,8 +62,8 @@ let is_encapsulated : mref_heap_stable_pred = (fun #a #p (r:mref a p) h ->
     Encapsulated? ((sel h map_shared) (addr_of r)))
 
 let gets_shared (s:set nat) (h0:heap) (h1:heap) =
-  (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (is_shared r h1)}
-    ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> (is_shared r h0 <==> is_shared r h1)) /\
+  (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern ((sel h1 map_shared) (addr_of r))}
+    ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> ((sel h0 map_shared) (addr_of r) = (sel h1 map_shared) (addr_of r))) /\
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (is_shared r h1)}
     ((Set.mem (addr_of r) s) /\ h0 `contains` r) ==> is_shared r h1)
 
@@ -665,7 +665,7 @@ let sst_write'' #a (#rel:preorder a) (r:mref a rel) (v:a)
 
 let gets_encapsulated (s:set nat) (h0:heap) (h1:heap) =
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern ((sel h1 map_shared) (addr_of r))}
-    ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> (sel h0 map_shared) (addr_of r) = (sel h1 map_shared) (addr_of r)) /\ //(is_encapsulated r h0 <==> is_encapsulated r h1)) /\
+    ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> (sel h0 map_shared) (addr_of r) = (sel h1 map_shared) (addr_of r)) /\
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (is_encapsulated r h1)}
     ((Set.mem (addr_of r) s) /\ h0 `contains` r) ==> is_encapsulated r h1)
 
@@ -704,9 +704,9 @@ let lemma_sst_encapsulate_preserves_shared #a (#rel:preorder a) (x:mref a rel) (
         assert (addr_of x =!= addr_of map_shared);
         assert (is_private r h0 \/ is_encapsulated r h0);
         introduce is_private r h0 ==> forall_refs_heap is_shared h1 (sel h1 r) with _. begin
-          introduce addr_of x = addr_of r ==> forall_refs_heap is_shared h1 (sel h1 r) with _. begin
+          introduce addr_of x = addr_of r ==> False with _. begin
             assert (is_encapsulated r h1);
-            assert (is_shared r h1)            // r is both encapsulated and shared in the final state
+            assert (is_shared r h1)
           end
         end
       end

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -64,7 +64,7 @@ let is_encapsulated : mref_heap_stable_pred = (fun #a #p (r:mref a p) h ->
 let gets_shared (s:set nat) (h0:heap) (h1:heap) =
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern ((sel h1 map_shared) (addr_of r))}
     ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> ((sel h0 map_shared) (addr_of r) = (sel h1 map_shared) (addr_of r) /\
-                                                        h0 `contains` map_shared <==> h1 `contains` map_shared)) /\
+                                                        h0 `contains` map_shared <==> h1 `contains` map_shared)) /\   // DA: should abstract this into a separate "not_changed" relation
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (is_shared r h1)}
     ((Set.mem (addr_of r) s) /\ h0 `contains` r) ==> is_shared r h1)
 

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -111,6 +111,11 @@ let modifies_only_shared (h0:heap) (h1:heap) : Type0 =
     (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0)) ==> sel h0 r == sel h1 r) /\
   unmodified_common h0 h1
 
+let modifies_only_shared_and_encapsulated (h0:heap) (h1:heap) : Type0 =
+  (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (sel h1 r)}
+    (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0 \/ is_encapsulated r h0)) ==> sel h0 r == sel h1 r) /\
+  unmodified_common h0 h1
+
 let ctrans_ref_pred (h:heap) (pred:mref_heap_stable_pred) =
   (** forall references, if r satisfies pred in h, then the references r points to refs that also satisfy pred **)
   (forall (t:shareable_typ) (r:ref (to_Type t)).

--- a/state/SharedRefs.fsti
+++ b/state/SharedRefs.fsti
@@ -63,7 +63,8 @@ let is_encapsulated : mref_heap_stable_pred = (fun #a #p (r:mref a p) h ->
 
 let gets_shared (s:set nat) (h0:heap) (h1:heap) =
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern ((sel h1 map_shared) (addr_of r))}
-    ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> ((sel h0 map_shared) (addr_of r) = (sel h1 map_shared) (addr_of r))) /\
+    ((~ (Set.mem (addr_of r) s)) /\ h0 `contains` r) ==> ((sel h0 map_shared) (addr_of r) = (sel h1 map_shared) (addr_of r) /\
+                                                        h0 `contains` map_shared <==> h1 `contains` map_shared)) /\
   (forall (a:Type) (rel:preorder a) (r:mref a rel).{:pattern (is_shared r h1)}
     ((Set.mem (addr_of r) s) /\ h0 `contains` r) ==> is_shared r h1)
 

--- a/state/TargetLang.fst
+++ b/state/TargetLang.fst
@@ -60,7 +60,7 @@ instance targetlang_arrow pspec t1 t2 {| c1:targetlang pspec t1 |} {| c2:targetl
 
 unfold
 let default_spec_rel (h0:heap) (h1:heap) = 
-  modifies_only_shared h0 h1 /\ gets_shared Set.empty h0 h1
+  modifies_only_shared_and_encapsulated h0 h1 /\ gets_shared Set.empty h0 h1
 
 let default_spec_rel_trans (h0:heap) (h1:heap) (h2:heap) 
 : Lemma (requires (default_spec_rel h0 h1 /\ default_spec_rel h1 h2)) 
@@ -68,9 +68,9 @@ let default_spec_rel_trans (h0:heap) (h1:heap) (h2:heap)
         [SMTPat (default_spec_rel h0 h1); SMTPat (default_spec_rel h1 h2)]
 = 
   introduce forall (a:Type) (rel:FStar.Preorder.preorder a) (r:mref a rel).
-                                    (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0)) ==> sel h0 r == sel h2 r with
+                                    (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0 \/ is_encapsulated r h0)) ==> sel h0 r == sel h2 r with
   begin
-    introduce  (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0)) ==> sel h0 r == sel h2 r with _.
+    introduce  (h0 `contains` r /\ ~(compare_addrs r map_shared) /\ ~(is_shared r h0 \/ is_encapsulated r h0)) ==> sel h0 r == sel h2 r with _.
     begin
       introduce ~(h0 `contains` map_shared) ==> ~(h1 `contains` map_shared) with _.
       begin


### PR DESCRIPTION
Instead of booleans, `map_shared` now maps addresses to Private, Shared, or Encapsulated reference kinds. 

Previous functionality upgraded to account for encapsulated references. 

New operations (`encapsulate` and `sst_encapsulate`) added for encapsulating a private reference.